### PR TITLE
Pass printf arguments through a format string.

### DIFF
--- a/autotest.c
+++ b/autotest.c
@@ -49,7 +49,7 @@ static int dump_file(const char* path)
 			    || !strncmp(line, "+++ ", 4)
 			    || !strncmp(line, "@@ ", 3))
 				continue;
-			printf(line);
+			printf("%s", line);
 		}
 		fclose(f);
 	}

--- a/merge_seq.c
+++ b/merge_seq.c
@@ -32,7 +32,7 @@ static int print_line(const struct line_buf* line)
 
 	if (!line->buf[0]) return 0;
 	if (!line->sequence_size || line->left_digit_start_o < 0) {
-		printf(line->buf);
+		printf("%s", line->buf);
 		return 0;
 	}
 	if (line->right_digit_start_o < 0)
@@ -53,7 +53,7 @@ static int print_line(const struct line_buf* line)
 			line->right_digit_base,
 			line->right_digit_base+line->sequence_size,
 			&line->buf[line->right_digit_end_o]);
-	printf(buf);
+	printf("%s", buf);
 	return 0;
 }
 

--- a/sort_seq.c
+++ b/sort_seq.c
@@ -409,7 +409,7 @@ int main(int argc, char** argv)
 		// print first 800 lines
 		for (i = 0; i < 800; i++) {
 			if (i >= s_numlines) break;
-			printf(s_lines[i]);
+			printf("%s", s_lines[i]);
 		}
 		// move up last 200 lines to beginning of buffer
 		if (s_numlines > i) {


### PR DESCRIPTION
Fixes clang warnings:
autotest.c:52:11: warning: format string is not a string literal
      (potentially insecure) [-Wformat-security]