### PR TITLE
%lX is too small to contain uint64 on 32-bit platforms, so use %llX.

### DIFF
--- a/libs/bit_frames.c
+++ b/libs/bit_frames.c
@@ -1204,19 +1204,19 @@ static int extract_logic(struct extract_state* es)
 
 		   	if (mi20) {
 				fprintf(stderr, "#E %s:%i y%i x%i l%i "
-				  "mi20 0x%016lX\n",
+				  "mi20 0x%016llX\n",
 				  __FILE__, __LINE__, y, x, l_col, mi20);
 				continue;
 			}
 		   	if (mi23_M) {
 				fprintf(stderr, "#E %s:%i y%i x%i l%i "
-				  "mi23_M 0x%016lX\n",
+				  "mi23_M 0x%016llX\n",
 				  __FILE__, __LINE__, y, x, l_col, mi23_M);
 				continue;
 			}
 		   	if (mi2526) {
 				fprintf(stderr, "#E %s:%i y%i x%i l%i "
-				  "mi2526 0x%016lX\n",
+				  "mi2526 0x%016llX\n",
 				  __FILE__, __LINE__, y, x, l_col, mi2526);
 				continue;
 			}

--- a/libs/floorplan.c
+++ b/libs/floorplan.c
@@ -319,7 +319,7 @@ int printf_LOGIC(FILE* f, struct fpga_model* model,
 			if (cfg->a2d[j].flags & LUT6VAL_SET) {
 				RC_ASSERT(model, !ULL_HIGH32(cfg->a2d[j].lut6_val));
 				if (print_hex_vals)
-					fprintf(f, "%s %c6_lut_val 0x%016lX\n",
+					fprintf(f, "%s %c6_lut_val 0x%016llX\n",
 						pref, 'A'+j, cfg->a2d[j].lut6_val);
 				else {
 					str = bool_bits2str(cfg->a2d[j].lut6_val, 32);
@@ -340,7 +340,7 @@ int printf_LOGIC(FILE* f, struct fpga_model* model,
 		} else {
 			if (cfg->a2d[j].flags & LUT6VAL_SET) {
 				if (print_hex_vals)
-					fprintf(f, "%s %c6_lut_val 0x%016lX\n",
+					fprintf(f, "%s %c6_lut_val 0x%016llX\n",
 						pref, 'A'+j, cfg->a2d[j].lut6_val);
 				else {
 					str = bool_bits2str(cfg->a2d[j].lut6_val, 64);

--- a/libs/helper.c
+++ b/libs/helper.c
@@ -462,7 +462,7 @@ void printf_type2(uint8_t *d, int len, int inpos, int num_entries)
 	for (i = 0; i < num_entries; i++) {
 		u64 = frame_get_u64(&d[inpos+i*8]);
 		if (!u64) continue;
-		printf("type2 8*%i 0x%016lX\n", i, u64);
+		printf("type2 8*%i 0x%016llX\n", i, u64);
 		for (j = 0; j < 4; j++) {
 			u16 = frame_get_u16(&d[inpos+i*8+j*2]);
 			if (u16)


### PR DESCRIPTION
Fixes warnings with clang:

helper.c:465:38: warning: format specifies type 'unsigned long' but the argument
      has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
