### PR TITLE
use clang-3.8 in Makefile.common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@
 # For details see the UNLICENSE file at the root of the source tree.
 #
 
-CC = clang-3.6
-
 CFLAGS  += -I$(CURDIR)/libs
 
 LDFLAGS += -Wl,-rpath,$(CURDIR)/libs

--- a/Makefile.common
+++ b/Makefile.common
@@ -20,6 +20,7 @@ CFLAGS += -Wall -Wshadow -Wmissing-prototypes -Wmissing-declarations \
 
 # ----- Verbosity control -----------------------------------------------------
 
+CC = clang-3.8
 CPP := $(CPP)   # make sure changing CC won't affect CPP
 
 CC_normal	:= $(CC)

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -6,8 +6,6 @@
 # For details see the UNLICENSE file at the root of the source tree.
 #
 
-CC = clang-3.6
-
 LIBS_VERSION_MAJOR = 0
 LIBS_VERSION = $(LIBS_VERSION_MAJOR).0.0
 

--- a/mini-jtag/Makefile
+++ b/mini-jtag/Makefile
@@ -5,7 +5,6 @@
 # For details see the UNLICENSE file at the root of the source tree.
 #
 
-CC = clang-3.6
 LDLIBS += `pkg-config libftdi --libs`
 OBJS := mini-jtag.o load-bits.o jtag.o
 


### PR DESCRIPTION
Why using clang-3.6 ? In my debian I have clang-3.5 and 3.8.
Do you think that we can use clang-3.8 instead of 3.6 ?
I just tested, it's compile well on 3.5 and 3.8